### PR TITLE
Add an option to add a simple favicon.ico to the root of the Contao installation

### DIFF
--- a/system/modules/easyFavicon/classes/easyFavicon.php
+++ b/system/modules/easyFavicon/classes/easyFavicon.php
@@ -67,6 +67,11 @@ class easyFavicon extends \Frontend
 			{
 				$favicon = 'share/favicon-' . $rootPage->alias . '.ico';
 				$this->createIco( TL_ROOT . '/' . $objFavicon->path, $favicon );
+				if($rootPage->faviconToRoot)
+				{
+					$rootFavicon = 'favicon.ico';
+					$this->createIco( TL_ROOT . '/' . $objFavicon->path, 'favicon.ico' );
+				}
 			}
 			
 			if( $favicon )

--- a/system/modules/easyFavicon/dca/tl_page.php
+++ b/system/modules/easyFavicon/dca/tl_page.php
@@ -24,7 +24,7 @@ $GLOBALS['TL_DCA']['tl_page']['palettes']['__selector__'][] = 'addAppleTouchIcon
 $GLOBALS['TL_DCA']['tl_page']['palettes']['root'] =  str_replace('{publish_legend}', '{favicon_legend:hide},addFavicon,addAppleTouchIcon;{publish_legend}', $GLOBALS['TL_DCA']['tl_page']['palettes']['root']);
 
 // Subpalettes
-$GLOBALS['TL_DCA']['tl_page']['subpalettes']['addFavicon'] = 'faviconSRC';
+$GLOBALS['TL_DCA']['tl_page']['subpalettes']['addFavicon'] = 'faviconSRC,faviconToRoot';
 $GLOBALS['TL_DCA']['tl_page']['subpalettes']['addAppleTouchIcon'] = 'appleTouchIconSRC';
 
 // Fields
@@ -45,6 +45,15 @@ $GLOBALS['TL_DCA']['tl_page']['fields']['faviconSRC'] = array
 	'explanation'		=> 'faviconSRCexpl',
 	'eval'				=> array('helpwizard'=>true, 'filesOnly'=>true, 'fieldType'=>'radio', 'extensions' =>'ico,jpg,jpeg,png,gif', 'mandatory'=>true, 'tl_class'=>'w50 easyFavicon'),
 	'sql'				=> "binary(16) NULL"
+);
+
+$GLOBALS['TL_DCA']['tl_page']['fields']['faviconToRoot'] = array
+(
+	'label'				=> array('Favicon to ROOT', 'Add this favicon as favicon.ico to the root'),
+	'exclude'			=> true,
+	'inputType'			=> 'checkbox',
+	'eval'				=> array('unique'=>true, 'tl_class'=>'clr w50'),
+	'sql'				=> "char(1) NOT NULL default ''"
 );
 
 $GLOBALS['TL_DCA']['tl_page']['fields']['addAppleTouchIcon'] = array


### PR DESCRIPTION
Hallo Markus. Weil ich immer wieder das erzeugte share/favicon-rootpage.ico herunterlade und als favicon.ico wieder in den root der Installation hochlade, habe ich diese Option mal als Checkbox hinzugefügt. Die Sprachbausteine sind noch hardcodiert.
![easyfavicon-favicontoroot](https://cloud.githubusercontent.com/assets/1143013/21290579/02cdd39e-c4c0-11e6-9006-13c11916896d.png)
Vielleicht magst du das ja übernehmen.
