### PR TITLE
PHP 8.0 Kompatibilität

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"source": "https://github.com/Ma3xl3/Contao-EasyFavicon"
 	},
 	"require": {
-		"php": "^5.6|^7.0",
+		"php": "^5.6|^7.0|^8.0",
 		"contao/core-bundle": "^4.4",
 		"chrisjean/php-ico" : "^1.0.4"
 	},


### PR DESCRIPTION
Leider ist ein Update von Contao nicht mehr möglich, da dieses Bundle mit PHP8 nicht kompatibel ist. Gleichzeitig sehe ich kein Hindernis, sodass man php8 einfach der composer.json hinzufügen kann?!